### PR TITLE
Change in packaging of business-index-exporter module

### DIFF
--- a/jobs/project/pipeline/build/jobs.groovy
+++ b/jobs/project/pipeline/build/jobs.groovy
@@ -19,8 +19,8 @@ new JobBuilder(
 new JobBuilder(
         project: Project.BusinessIndexExporter,
         upstreamProjects: [Project.BusinessLibs],
-        buildCommand: './bin/sbt clean assembly',
-        buildArtifact: 'target/scala-2.*/business-index-exporter-assembly-*.jar'
+        buildCommand: './bin/sbt clean test dist',
+        buildArtifact: 'target/universal/business-index-exporter-*.zip'
 ).build(this)
 
 new JobBuilder(


### PR DESCRIPTION
This is to reflect change in packaging of business-index-exporter module from assembly JAR to ZIP archive.
